### PR TITLE
Remove deprecated stylelint-config-prettier

### DIFF
--- a/packages/stylelint-config-react-native/package.json
+++ b/packages/stylelint-config-react-native/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@untile/eslint-config-typescript-react": "*",
     "@untile/stylelint-config-react": "*",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-react-native": "^2.6.0"
   },
   "devDependencies": {

--- a/packages/stylelint-config-react-native/src/index.js
+++ b/packages/stylelint-config-react-native/src/index.js
@@ -4,7 +4,7 @@
  */
 
 module.exports = {
-  extends: ['@untile/stylelint-config-react', 'stylelint-config-prettier'],
+  extends: ['@untile/stylelint-config-react'],
   plugins: ['stylelint-react-native'],
   rules: {
     'max-empty-lines': 1,

--- a/packages/stylelint-config-react/package.json
+++ b/packages/stylelint-config-react/package.json
@@ -40,7 +40,6 @@
     "@stylelint/postcss-css-in-js": "^0.38.0",
     "postcss": "^8.4.21",
     "postcss-syntax": "^0.36.2",
-    "stylelint-config-prettier": "^9.0.5",
     "stylelint-config-recommended": "^10.0.1",
     "stylelint-config-styled-components": "^0.1.1",
     "stylelint-order": "^6.0.3"

--- a/packages/stylelint-config-react/src/index.js
+++ b/packages/stylelint-config-react/src/index.js
@@ -17,8 +17,7 @@ module.exports = {
   customSyntax: '@stylelint/postcss-css-in-js',
   extends: [
     'stylelint-config-recommended',
-    'stylelint-config-styled-components',
-    'stylelint-config-prettier'
+    'stylelint-config-styled-components'
   ],
   plugins: ['stylelint-order'],
   rules: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5490,11 +5490,6 @@ style-search@^0.1.0:
   resolved "https://registry.yarnpkg.com/style-search/-/style-search-0.1.0.tgz#7958c793e47e32e07d2b5cafe5c0bf8e12e77902"
   integrity sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==
 
-stylelint-config-prettier@^9.0.5:
-  version "9.0.5"
-  resolved "https://registry.yarnpkg.com/stylelint-config-prettier/-/stylelint-config-prettier-9.0.5.tgz#9f78bbf31c7307ca2df2dd60f42c7014ee9da56e"
-  integrity sha512-U44lELgLZhbAD/xy/vncZ2Pq8sh2TnpiPvo38Ifg9+zeioR+LAkHu0i6YORIOxFafZoVg0xqQwex6e6F25S5XA==
-
 stylelint-config-recommended@^10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/stylelint-config-recommended/-/stylelint-config-recommended-10.0.1.tgz#25a8828acf6cde87dac6db2950c8c4ed82a69ae1"


### PR DESCRIPTION
From Stylelint v15 onwards, Stylelint will not enforce stylistic code conventions. 
This will be handled by the prettier plugin itself (or other).
Check https://github.com/prettier/stylelint-config-prettier#stylelint-config-prettier for more details.