### PR TITLE
Fix labeler workflow syntax error

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -2,7 +2,8 @@ name: Pull Request Labeler
 
 on:
   pull_request_target:
-    [types, synchronize]
+    types:
+      - synchronize
 
 jobs:
   triage:


### PR DESCRIPTION
This PR fixes `labeler.yml` workflow syntax error.