### PR TITLE
Fix Labeler workflow events

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,14 +1,12 @@
 name: Pull Request Labeler
 
 on:
-  pull_request_target:
-    types:
-      - synchronize
+  pull_request_target
 
 jobs:
   triage:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
This workflow is triggered when a pull request is opened, reopened, or synchronized.