### PR TITLE
Remove test workflow from push on master branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - master
 
-  push:
-    branches:
-      - master
-
 jobs:
   build:
     timeout-minutes: 20
@@ -42,5 +38,5 @@ jobs:
 
       - name: Lint commits
         uses: wagoid/commitlint-github-action@v5
-        with: 
+        with:
           configFile: .commitlintrc.js


### PR DESCRIPTION
This PR removes the test workflow for pushes in master.
This occurred when a new release was pushed into master, but there was no need for it.