### PR TITLE
Update @untile/eslint-config to v1.0.2

### DIFF
--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@babel/core": "^7.21.4",
     "@babel/parser": "^7.21.4",
-    "@untile/eslint-config": "^1.0.0",
+    "@untile/eslint-config": "^1.0.2",
     "eslint": "^8.38.0",
     "jest": "^29.5.0",
     "prettier": "^2.8.7",


### PR DESCRIPTION
This PR updates `@untile/eslint-config` dependency to `v1.0.2`