### PR TITLE
Update @untile/github-changelog-generator to v1.0.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "json5": "^2.2.1"
   },
   "devDependencies": {
-    "@untile/github-changelog-generator": "^1.0.2",
+    "@untile/github-changelog-generator": "^1.0.3",
     "husky": "^8.0.3",
     "lint-staged": "^13.2.1",
     "sort-package-json": "^2.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,10 +1865,10 @@
     "@typescript-eslint/types" "5.58.0"
     eslint-visitor-keys "^3.3.0"
 
-"@untile/github-changelog-generator@^1.0.2":
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/@untile/github-changelog-generator/-/github-changelog-generator-1.0.2.tgz#ea0761fa08141d11c7b2bc1e2ab002fe62c99c24"
-  integrity sha512-/0v+yXnHMyykeyLh7eiWDw/V/9neM5m0E0Hf70Jk20b1eqzY+0TKsKtuJbYInbA+KhEg+tg6tGwnqZLsrPqkbQ==
+"@untile/github-changelog-generator@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@untile/github-changelog-generator/-/github-changelog-generator-1.0.3.tgz#33bbc9efc03816d983d3afaa322a22e36c26f7c4"
+  integrity sha512-WMhVJMc6w84lDmZql9aY0xIzAqDKuK1IsF40Pc9+ShBi9+CF05cdYvkVKQcnwOPB0piubtqCqT+0O4YPag1+jg==
   dependencies:
     "@octokit/graphql" "^5.0.5"
     execa "4.1.0"


### PR DESCRIPTION
This PR updates `@untile/github-changelog-generator` dependency to **v1.0.3**.