### PR TITLE
Update stylelint-config-react to v1.0.1

### DIFF
--- a/packages/stylelint-config-react-native/package.json
+++ b/packages/stylelint-config-react-native/package.json
@@ -37,8 +37,7 @@
     ]
   },
   "dependencies": {
-    "@untile/eslint-config-typescript-react": "*",
-    "@untile/stylelint-config-react": "*",
+    "@untile/stylelint-config-react": "^1.0.1",
     "stylelint-react-native": "^2.6.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates stylelint-config-react to v1.0.1 and also removes unneeded @untile/eslint-config-typescript-react dependency.