### PR TITLE
Add eslint-config-typescript package

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -31,3 +31,7 @@ stylelint-config-react:
 # Label for package eslint-config-typescript-react.
 eslint-config-typescript-react:
   - packages/eslint-config-typescript-react/**/*
+
+# Label for package eslint-config-typescript.
+eslint-config-typescript:
+  - packages/eslint-config-typescript/**/*

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "release:commitlint-config": "yarn workspace @untile/commitlint-config release",
     "release:eslint-config": "yarn workspace @untile/eslint-config release",
     "release:eslint-config-react": "yarn workspace @untile/eslint-config-react release",
+    "release:eslint-config-typescript": "yarn workspace @untile/eslint-config-typescript release",
     "release:eslint-config-typescript-react": "yarn workspace @untile/eslint-config-typescript-react release",
     "release:eslint-config-typescript-react-native": "yarn workspace @untile/eslint-config-typescript-react-native release",
     "release:prettier-config": "yarn workspace @untile/prettier-config release",

--- a/packages/eslint-config-typescript/.eslintrc.js
+++ b/packages/eslint-config-typescript/.eslintrc.js
@@ -1,0 +1,8 @@
+
+/**
+ * Eslint configuration.
+ */
+
+module.exports = {
+  extends: ['@untile/eslint-config']
+};

--- a/packages/eslint-config-typescript/LICENSE
+++ b/packages/eslint-config-typescript/LICENSE
@@ -1,0 +1,23 @@
+The MIT License
+
+MIT License
+
+Copyright (c) 2023 Untile
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/eslint-config-typescript/README.md
+++ b/packages/eslint-config-typescript/README.md
@@ -1,0 +1,63 @@
+<p align="center">
+  <br><img width="250" src="https://untile.pt/logo.png" /><br>
+</p>
+
+<h1 align="center">
+  @untile/eslint-config-typescript
+</h1>
+
+<h4 align="center">
+  Untile-flavored ESLint typescript config. Extends `@untile/eslint-config`.
+</h4>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@untile/eslint-config-typescript">
+    <img src="https://img.shields.io/npm/v/@untile/eslint-config-typescript.svg?style=for-the-badge" alt="NPM version" />
+  </a>
+  <a href="https://github.com/untile/js-configs/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge" alt="Untile js-config is released under the MIT license." />
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=untiledigital">
+    <img src="https://img.shields.io/twitter/follow/untiledigital.svg?label=Follow%20@untiledigital&style=for-the-badge" alt="Follow @untiledigital" />
+  </a>
+</p>
+
+## Installation
+
+With `npm`:
+
+```sh
+npm install eslint @untile/eslint-config-typescript --save-dev
+```
+
+Or using `yarn`:
+
+```sh
+yarn add eslint @untile/eslint-config-typescript -D
+```
+
+## Setup
+
+Create an `.eslintrc.js` file with the following:
+
+```js
+extends: ['@untile/eslint-config-typescript']
+```
+
+## Usage
+
+Add the following `script` to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint ."
+  }
+}
+```
+
+and run the linter with:
+
+```sh
+yarn lint
+```

--- a/packages/eslint-config-typescript/jest.config.js
+++ b/packages/eslint-config-typescript/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+
+/**
+ * Export jest configuration.
+ */
+
+module.exports = {
+  coverageDirectory: 'coverage',
+  coverageReporters: ['html', 'lcov', 'text'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(test/.*\\.test.(js|ts))$',
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
+  }
+};

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -1,0 +1,63 @@
+{
+  "name": "@untile/eslint-config-typescript",
+  "version": "0.0.0",
+  "description": "Untile-flavored ESLint config typescript",
+  "keywords": [
+    "config",
+    "eslint",
+    "lint",
+    "typescript"
+  ],
+  "homepage": "https://github.com/untile/js-configs/tree/master/packages/eslint-config-typescript/#readme",
+  "bugs": {
+    "url": "https://github.com/untile/js-configs/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/untile/js-configs.git"
+  },
+  "license": "MIT",
+  "main": "src",
+  "scripts": {
+    "lint": "eslint . --ignore-pattern 'test/fixtures/*'",
+    "release": "../../bin/release.sh @untile/eslint-config-typescript",
+    "test": "jest",
+    "test:watch": "jest --watch --notify"
+  },
+  "lint-staged": {
+    "!(test/fixtures/**/*)*.(ts|js)": [
+      "eslint"
+    ],
+    "package.json": [
+      "sort-package-json"
+    ],
+    "yarn.lock": [
+      "yarn-deduplicate"
+    ]
+  },
+  "dependencies": {
+    "@typescript-eslint/eslint-plugin": "^5.58.0",
+    "@typescript-eslint/parser": "^5.58.0",
+    "@untile/eslint-config": "^1.0.3",
+    "eslint-config-prettier": "^8.6.0",
+    "eslint-plugin-sort-class-members": "^1.17.0",
+    "eslint-plugin-sort-imports-es6-autofix": "^0.6.0",
+    "eslint-plugin-typescript-sort-keys": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.0",
+    "eslint": "^8.38.0",
+    "jest": "^29.5.0",
+    "node-notifier": "^10.0.1",
+    "ts-jest": "^29.1.0",
+    "typescript": "^5.0.4"
+  },
+  "peerDependencies": {
+    "eslint": "8",
+    "prettier": "2.8",
+    "typescript": ">=4.9.0 || >=5.0.0"
+  },
+  "engines": {
+    "node": ">=14.18"
+  }
+}

--- a/packages/eslint-config-typescript/src/index.js
+++ b/packages/eslint-config-typescript/src/index.js
@@ -1,0 +1,37 @@
+/**
+ * Export `eslint-config-typescript` shared configuration preset.
+ */
+
+module.exports = {
+  extends: [
+    '@untile/eslint-config',
+    'plugin:@typescript-eslint/recommended',
+    'prettier'
+  ],
+  parser: '@typescript-eslint/parser',
+  plugins: [
+    '@typescript-eslint',
+    'sort-class-members',
+    'sort-imports-es6-autofix',
+    'typescript-sort-keys'
+  ],
+  rules: {
+    '@typescript-eslint/comma-dangle': ['error'],
+    '@typescript-eslint/explicit-member-accessibility': 0,
+    '@typescript-eslint/explicit-module-boundary-types': 0,
+    '@typescript-eslint/indent': 0,
+    '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-unused-vars': 'error',
+    '@typescript-eslint/no-use-before-define': ['error'],
+    'comma-dangle': 0,
+    'new-cap': ['error', { capIsNewExceptions: ['BigNumber'] }],
+    'no-unused-vars': 0,
+    'no-use-before-define': 0,
+    'sort-imports-es6-autofix/sort-imports-es6': [2, {
+      ignoreCase: false,
+      ignoreMemberSort: false,
+      memberSyntaxSortOrder: ['none', 'all', 'multiple', 'single']
+    }],
+    'typescript-sort-keys/interface': 'error'
+  }
+};

--- a/packages/eslint-config-typescript/test/fixtures/correct.ts
+++ b/packages/eslint-config-typescript/test/fixtures/correct.ts
@@ -1,0 +1,32 @@
+// Avoid extra `no-unused-vars` violations.
+function noop() {
+  // Do nothing
+}
+
+// `@typescript-eslint/no-unused-vars`.
+const foo = '';
+
+noop(foo);
+
+// `@typescript-eslint/comma-dangle`.
+noop({ bar: 'bar', foo: 'foo' });
+
+// `typescript-sort-keys/interface`.
+export interface FOOBAR {
+  a: any;
+  b: any;
+  c: any;
+}
+
+// `@typescript-eslint/no-use-before-define`.
+type FooBiz = string;
+const foobiz: FooBiz = '';
+
+noop(foobiz);
+
+// @typescript-eslint/explicit-module-boundary-types
+export const explicitString = () => 'test';
+export const typedExplicitString = (): string => 'test';
+
+// Force this TS source to be a module.
+export {};

--- a/packages/eslint-config-typescript/test/fixtures/incorrect.ts
+++ b/packages/eslint-config-typescript/test/fixtures/incorrect.ts
@@ -1,0 +1,25 @@
+// Avoid extra `no-unused-vars` violations.
+function noop() {
+  // Do nothing
+}
+
+// `@typescript-eslint/no-unused-vars`.
+const foo = '';
+
+// `@typescript-eslint/comma-dangle`.
+noop({ bar: 'bar', foo: '', });
+
+// `@typescript-eslint/no-use-before-define`.
+noop(foobiz);
+
+const foobiz = '';
+
+// `typescript-sort-keys/interface`.
+export interface FOO {
+  a: any;
+  c: any;
+  b: any;
+}
+
+// Force this TS source to be a module.
+export {};

--- a/packages/eslint-config-typescript/test/index.test.ts
+++ b/packages/eslint-config-typescript/test/index.test.ts
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+const { ESLint } = require('eslint');
+const path = require('path');
+
+/**
+ * Tests for `@untile/eslint-config-typescript`.
+ */
+
+describe('@untile/eslint-config-typescript', () => {
+  const linter = new ESLint({
+    overrideConfigFile: path.join(__dirname, '..', 'src', 'index.js')
+  });
+
+  it('should not generate any violation for correct code', async () => {
+    const source = path.join(__dirname, 'fixtures', 'correct.ts');
+    const results = await linter.lintFiles([source]);
+
+    expect(results[0]?.errorCount).toEqual(0);
+  });
+
+  it('should generate violations for incorrect code', async () => {
+    const source = path.join(__dirname, 'fixtures', 'incorrect.ts');
+    const results = await linter.lintFiles([source]);
+    const violations = results[0].messages.map(violation => violation.ruleId);
+
+    expect(violations).toEqual([
+      '@typescript-eslint/no-unused-vars',
+      '@typescript-eslint/comma-dangle',
+      '@typescript-eslint/no-use-before-define',
+      'typescript-sort-keys/interface'
+    ]);
+  });
+});

--- a/packages/eslint-config-typescript/tsconfig.jest.json
+++ b/packages/eslint-config-typescript/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "commonjs"
+  }
+}


### PR DESCRIPTION
This PR adds the `eslint-config-typescript` package to be used for both untile teams, frontend and backend, and in libs without react as a dependency.