### PR TITLE
Add error for `no-explicit-any`

### DIFF
--- a/packages/eslint-config-typescript/src/index.js
+++ b/packages/eslint-config-typescript/src/index.js
@@ -20,7 +20,10 @@ module.exports = {
     '@typescript-eslint/explicit-member-accessibility': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/indent': 0,
-    '@typescript-eslint/no-explicit-any': 0,
+    '@typescript-eslint/no-explicit-any': ['error', {
+      fixToUnknown: true,
+      ignoreRestArgs: false
+    }],
     '@typescript-eslint/no-unused-vars': 'error',
     '@typescript-eslint/no-use-before-define': ['error'],
     'comma-dangle': 0,

--- a/packages/eslint-config-typescript/test/fixtures/correct.ts
+++ b/packages/eslint-config-typescript/test/fixtures/correct.ts
@@ -13,9 +13,9 @@ noop({ bar: 'bar', foo: 'foo' });
 
 // `typescript-sort-keys/interface`.
 export interface FOOBAR {
-  a: any;
-  b: any;
-  c: any;
+  a: unknown;
+  b: unknown;
+  c: unknown;
 }
 
 // `@typescript-eslint/no-use-before-define`.

--- a/packages/eslint-config-typescript/test/fixtures/incorrect.ts
+++ b/packages/eslint-config-typescript/test/fixtures/incorrect.ts
@@ -14,11 +14,16 @@ noop(foobiz);
 
 const foobiz = '';
 
+// `@typescript-eslint/no-explicit-any`.
+const bar: any = '';
+
+noop(bar);
+
 // `typescript-sort-keys/interface`.
 export interface FOO {
-  a: any;
-  c: any;
-  b: any;
+  a: unknown;
+  c: unknown;
+  b: unknown;
 }
 
 // Force this TS source to be a module.

--- a/packages/eslint-config-typescript/test/index.test.ts
+++ b/packages/eslint-config-typescript/test/index.test.ts
@@ -32,6 +32,7 @@ describe('@untile/eslint-config-typescript', () => {
       '@typescript-eslint/no-unused-vars',
       '@typescript-eslint/comma-dangle',
       '@typescript-eslint/no-use-before-define',
+      '@typescript-eslint/no-explicit-any',
       'typescript-sort-keys/interface'
     ]);
   });


### PR DESCRIPTION
`any` is an escape hatch, equivalent to disabling typescript. We should avoid it as much as possible, so this rule should be enabled by default. It can be disabled on a case-by-case basis if absolutely necessary. 

Every time someone uses `any`, a typescript dev cries