### PR TITLE
Bump prettier to version 3 and printWidth to 120

### DIFF
--- a/packages/eslint-config-react/package.json
+++ b/packages/eslint-config-react/package.json
@@ -52,7 +52,7 @@
   },
   "peerDependencies": {
     "eslint": "8",
-    "prettier": "2.8"
+    "prettier": "3"
   },
   "engines": {
     "node": ">=16"

--- a/packages/eslint-config-typescript/package.json
+++ b/packages/eslint-config-typescript/package.json
@@ -54,7 +54,7 @@
   },
   "peerDependencies": {
     "eslint": "8",
-    "prettier": "2.8",
+    "prettier": "3",
     "typescript": ">=4.9.0 || >=5.0.0"
   },
   "engines": {

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -20,8 +20,7 @@
   "scripts": {
     "lint": "eslint . --ignore-pattern 'test/fixtures/*'",
     "release": "../../bin/release.sh @untile/prettier-config",
-    "test": "jest",
-    "test:watch": "jest --watch --notify"
+    "test": "yarn node --experimental-vm-modules $(yarn bin jest)"
   },
   "lint-staged": {
     "!(test/fixtures/**/*)*.js": [
@@ -40,11 +39,11 @@
     "@untile/eslint-config": "^1.0.3",
     "eslint": "^8.45.0",
     "jest": "^29.6.1",
-    "prettier": "^2.8.8",
+    "prettier": "^3.0.0",
     "react": "^18.2.0"
   },
   "peerDependencies": {
-    "prettier": "2.8"
+    "prettier": "3"
   },
   "engines": {
     "node": ">=16"

--- a/packages/prettier-config/src/index.js
+++ b/packages/prettier-config/src/index.js
@@ -9,7 +9,7 @@ module.exports = {
   endOfLine: 'lf',
   htmlWhitespaceSensitivity: 'css',
   jsxSingleQuote: true,
-  printWidth: 80,
+  printWidth: 120,
   proseWrap: 'preserve',
   quoteProps: 'as-needed',
   requirePragma: false,

--- a/packages/prettier-config/test/fixtures/correct.js
+++ b/packages/prettier-config/test/fixtures/correct.js
@@ -9,9 +9,9 @@ export const bracketSpacing = { foo: 'bar', baz: 'qux' };
 // jsxSingleQuote: true
 export const jsxSingleQuote = <div className='example'>Hello, World!</div>;
 
-// printWidth: 80
+// printWidth: 120
 export const printWidth =
-  'This is a very long line of text that will exceed the print width of 80 characters and will be wrapped by Prettier.';
+  'This is a very long line of text that will exceed the print width of 120 characters and will be wrapped by Prettier. This is a very long line of text that will exceed the print width of 120 characters and will be wrapped by Prettier.';
 
 // quoteProps: 'as-needed'
 export const quoteProps = {

--- a/packages/prettier-config/test/fixtures/incorrect.js
+++ b/packages/prettier-config/test/fixtures/incorrect.js
@@ -9,8 +9,8 @@ export const bracketSpacingViolation = {foo: 'bar', baz: 'qux'};
 // jsxSingleQuote: true
 export const jsxSingleQuoteViolation = <div className="example">Hello, World!</div>;
 
-// printWidth: 80
-export const printWidthViolation = "This is a very long line of text that will exceed the print width of 80 characters and will be wrapped by Prettier.";
+// printWidth: 120
+export const printWidthViolation = "This is a very long line of text that will exceed the print width of 120 characters and will be wrapped by Prettier. This is a very long line of text that will exceed the print width of 120 characters and will be wrapped by Prettier.";
 
 // quoteProps: 'as-needed'
 export const quotePropsViolation = {

--- a/packages/prettier-config/test/index.test.js
+++ b/packages/prettier-config/test/index.test.js
@@ -11,31 +11,28 @@ const prettier = require('prettier');
 const prettierConfig = require('../src/index');
 
 /**
- * Check.
- */
-
-const check = (content) => prettier.check(content, {
-  ...prettierConfig,
-  parser: 'babel'
-});
-
-/**
  * Tests for `@untile/prettier-config`.
  */
 
 describe('@untile/prettier-config', () => {
-  it('should not generate any violation for correct code', () => {
+  it('should not generate any violation for correct code', async () => {
     const source = path.resolve(__dirname, 'fixtures', 'correct.js');
     const content = fs.readFileSync(source, 'utf8');
-    const results = check(content);
+    const results = await prettier.check(content, {
+      ...prettierConfig,
+      parser: 'babel'
+    });
 
     expect(results).toBe(true);
   });
 
-  it('should generate violations for incorrect code', () => {
+  it('should generate violations for incorrect code', async () => {
     const source = path.resolve(__dirname, 'fixtures', 'incorrect.js');
     const content = fs.readFileSync(source, 'utf8');
-    const results = check(content);
+    const results = await prettier.check(content, {
+      ...prettierConfig,
+      parser: 'babel'
+    });
     
     expect(results).toBe(false);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5415,10 +5415,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.8.8:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.0.0.tgz#e7b19f691245a21d618c68bc54dc06122f6105ae"
+  integrity sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==
 
 pretty-format@^29.0.0, pretty-format@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
This PR bumps prettier to version 3 according to [migration-guide](https://prettier.io/blog/2023/07/05/3.0.0.html) and `printWidth` to 120 instead of 80.