### PR TITLE
Add rebuild command to release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -13,7 +13,7 @@ release() {
   local version=`grep -m1 version package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g'`
 
   # Generate changelog.
-  github-changelog-generator --future-release ${version} --package-name ${1}
+  github-changelog-generator --future-release ${version} --package-name ${1} --rebuild
 
   # Add modified files.
   git add .


### PR DESCRIPTION
This PR fixes the release script by adding the `--rebuild` command to changelog-generator after the migration to `v2.0.0`.
This was needed because the changelog-generator v2.0.0 has a bug related with PR already in a changelog in a monorepo.