### PR TITLE
Remove deprecated valid-jsdoc rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -230,7 +230,6 @@ module.exports = {
     strict: 'off',
     'switch-case/newline-between-switch-case': ['error', 'always', { fallthrough: 'never' }],
     'template-curly-spacing': 'error',
-    'valid-jsdoc': 'error',
     'vars-on-top': 'error',
     'wrap-iife': ['error', 'inside'],
     yoda: 'error'


### PR DESCRIPTION
This removes the `valid-jsdoc` rule since we do not use it, it's deprecated and it's throwing errors in eslint `v8.46.0´.

Deprecated since v5.10.0: https://eslint.org/blog/2018/11/jsdoc-end-of-life/

**Error Example:**
![image](https://github.com/untile/js-configs/assets/3527721/9480b905-35c0-4404-829b-f594c3faead5)
