### PR TITLE
Update release script

### DIFF
--- a/bin/release.sh
+++ b/bin/release.sh
@@ -10,7 +10,7 @@ release() {
   yarn version --no-git-tag-version --new-version ${2:-patch}
 
   # Get the new version number.
-  local version=`grep -m1 version package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g'`
+  local version=`grep -m1 "\"version\"" package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g'`
 
   # Generate changelog.
   github-changelog-generator --future-release ${version} --package-name ${1} --rebuild


### PR DESCRIPTION
#### Description
This PR fixes the release script: 
The command `grep -m1 version package.json | awk -F: '{ print $2 }' | sed 's/[", ]//g'` find the first occurrence of the pattern `version`. This means that if we have before the "version" line a value with the "version" pattern it will return it. The command is changed to find the pattern `"version"` instead. 

Example, if the `package.json` has this before the `version` key, it will not return the `version` value: 
`"name": "foo-version-bar"`.