### PR TITLE
Add @untile/biome-config package

### DIFF
--- a/packages/biome-config/LICENSE
+++ b/packages/biome-config/LICENSE
@@ -1,0 +1,23 @@
+The MIT License
+
+MIT License
+
+Copyright (c) 2025 Untile
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/biome-config/README.md
+++ b/packages/biome-config/README.md
@@ -1,0 +1,80 @@
+<p align="center">
+  <br><img width="250" src="https://untile.pt/logo.png" /><br>
+</p>
+
+<h1 align="center">
+  @untile/biome-config
+</h1>
+
+<h4 align="center">
+  A shareable Biome configuration that enforces Untile's code style. Based on our TypeScript React ESLint configuration, this package provides a modern, fast, and unified formatter and linter using [Biome](https://biomejs.dev).
+</h4>
+
+<p align="center">
+  <a href="https://www.npmjs.com/package/@untile/biome-config">
+    <img src="https://img.shields.io/npm/v/@untile/biome-config.svg?style=for-the-badge" alt="NPM version" />
+  </a>
+  <a href="https://github.com/untile/js-configs/blob/main/LICENSE">
+    <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=for-the-badge" alt="Untile js-config is released under the MIT license." />
+  </a>
+  <a href="https://twitter.com/intent/follow?screen_name=untiledigital">
+    <img src="https://img.shields.io/twitter/follow/untiledigital.svg?label=Follow%20@untiledigital&style=for-the-badge" alt="Follow @untiledigital" />
+  </a>
+</p>
+
+## Requirements
+
+- Node.js >= 20
+- ESLint >= 9
+- TypeScript >= 4.9.0
+- Biome >= 1.9
+
+## Installation
+
+With `npm`:
+
+```sh
+npm install @biomejs/biome @untile/biome-config --save-dev
+```
+
+Or using `yarn`:
+
+```sh
+yarn add @biomejs/biome @untile/biome-config -D
+```
+
+## Setup
+
+Create a `biome.json` file in your project root and extend this configuration:
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "extends": ["@untile/biome-config"]
+}
+```
+
+## Usage
+
+Add the following `script` to your `package.json`:
+
+```json
+{
+  "scripts": {
+    "biome:lint": "biome lint --error-on-warnings ."
+  }
+}
+```
+
+read more about the `biome:lint` script [here](https://biomejs.dev/linter/).
+
+or using as a formatter:
+
+```json
+{
+  "scripts": {
+    "biome:format": "biome format ."
+  }
+}
+
+read more about the `biome:format` script [here](https://biomejs.dev/formatter/).

--- a/packages/biome-config/biome.json
+++ b/packages/biome-config/biome.json
@@ -1,0 +1,163 @@
+{
+	"$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+	"vcs": { "enabled": false, "clientKind": "git", "useIgnoreFile": false },
+	"files": { "ignoreUnknown": false, "ignore": [] },
+	"formatter": {
+		"enabled": true,
+		"useEditorconfig": true,
+		"formatWithErrors": false,
+		"indentStyle": "space",
+		"indentWidth": 2,
+		"lineEnding": "lf",
+		"lineWidth": 120,
+		"attributePosition": "auto",
+		"bracketSpacing": true
+	},
+	"linter": {
+		"rules": {
+			"recommended": false,
+			"a11y": { "noBlankTarget": "error" },
+			"complexity": {
+				"noUselessConstructor": "error",
+				"noUselessLoneBlockStatements": "error",
+				"noUselessStringConcat": "error",
+				"noUselessTernary": "error",
+				"noUselessThisAlias": "error",
+				"noUselessTypeConstraint": "error",
+				"noUselessUndefinedInitialization": "error",
+				"noVoid": "error",
+				"noWith": "error",
+				"useArrowFunction": "error",
+				"useLiteralKeys": "error"
+			},
+			"correctness": {
+				"noChildrenProp": "error",
+				"noConstantCondition": "error",
+				"noInvalidUseBeforeDeclaration": "error",
+				"noUnusedVariables": "error",
+				"useArrayLiterals": "error",
+				"useJsxKeyInIterable": "error",
+				"useYield": "error"
+			},
+			"security": {
+				"noDangerouslySetInnerHtmlWithChildren": "error",
+				"noGlobalEval": "error"
+			},
+			"style": {
+				"noArguments": "error",
+				"noCommaOperator": "error",
+				"noNamespace": "error",
+				"noNegationElse": "error",
+				"noUselessElse": "error",
+				"noVar": "error",
+				"useAsConstAssertion": "error",
+				"useBlockStatements": "error",
+				"useCollapsedElseIf": "error",
+				"useConsistentArrayType": {
+					"level": "error",
+					"options": { "syntax": "shorthand" }
+				},
+				"useConsistentBuiltinInstantiation": "error",
+				"useConst": "error",
+				"useDefaultSwitchClause": "error",
+				"useShorthandAssign": "error",
+				"useSingleVarDeclarator": "error",
+				"useTemplate": "error",
+				"useThrowOnlyError": "error"
+			},
+			"suspicious": {
+				"noAssignInExpressions": "error",
+				"noCommentText": "error",
+				"noConfusingLabels": "error",
+				"noConsole": "error",
+				"noDoubleEquals": "error",
+				"noDuplicateClassMembers": "error",
+				"noDuplicateJsxProps": "error",
+				"noEmptyBlockStatements": "error",
+				"noExplicitAny": "error",
+				"noExtraNonNullAssertion": "error",
+				"noLabelVar": "error",
+				"noMisleadingInstantiator": "error",
+				"noPrototypeBuiltins": "error",
+				"noSelfCompare": "error",
+				"noShadowRestrictedNames": "error",
+				"noUnsafeDeclarationMerging": "error",
+				"useAwait": "error",
+				"useNamespaceKeyword": "error"
+			}
+		}
+	},
+	"javascript": {
+		"formatter": {
+			"jsxQuoteStyle": "single",
+			"quoteProperties": "asNeeded",
+			"trailingCommas": "none",
+			"semicolons": "always",
+			"arrowParentheses": "asNeeded",
+			"bracketSameLine": false,
+			"quoteStyle": "single",
+			"attributePosition": "auto",
+			"bracketSpacing": true
+		},
+		"globals": [
+			"node",
+			"es6",
+			"exports",
+			"require",
+			"__dirname",
+			"__filename",
+			"browser",
+			"module"
+		]
+	},
+	"overrides": [
+		{
+			"include": ["**/*.{js,jsx,mjs,cjs,ts,tsx,cts,mts}"],
+			"javascript": { "globals": [] },
+			"linter": {
+				"rules": {
+					"correctness": {
+						"useExhaustiveDependencies": "error",
+						"useHookAtTopLevel": "error"
+					},
+					"security": { "noDangerouslySetInnerHtml": "error" },
+					"style": { "noImplicitBoolean": "error" }
+				}
+			}
+		},
+		{
+			"include": ["**/*.ts", "**/*.tsx", "**/*.mts", "**/*.cts"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						"noConstAssign": "off",
+						"noGlobalObjectCalls": "off",
+						"noInvalidBuiltinInstantiation": "off",
+						"noInvalidConstructorSuper": "off",
+						"noNewSymbol": "off",
+						"noSetterReturn": "off",
+						"noUndeclaredVariables": "off",
+						"noUnreachable": "off",
+						"noUnreachableSuper": "off"
+					},
+					"style": {
+						"noArguments": "error",
+						"noVar": "error",
+						"useConst": "error"
+					},
+					"suspicious": {
+						"noClassAssign": "off",
+						"noDuplicateClassMembers": "off",
+						"noDuplicateObjectKeys": "off",
+						"noDuplicateParameters": "off",
+						"noFunctionAssign": "off",
+						"noImportAssign": "off",
+						"noRedeclare": "off",
+						"noUnsafeNegation": "off",
+						"useGetterReturn": "off"
+					}
+				}
+			}
+		}
+	]
+}

--- a/packages/biome-config/eslint.config.js
+++ b/packages/biome-config/eslint.config.js
@@ -1,0 +1,5 @@
+/**
+ * Eslint configuration.
+ */
+
+module.exports = require('../eslint-config-typescript-react/src/index.js');

--- a/packages/biome-config/jest.config.js
+++ b/packages/biome-config/jest.config.js
@@ -1,0 +1,16 @@
+/** @type {import('jest').Config} */
+
+/**
+ * Export jest configuration.
+ */
+
+module.exports = {
+  coverageDirectory: 'coverage',
+  coverageReporters: ['html', 'lcov', 'text'],
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testRegex: '(test/.*\\.test.(js|ts))$',
+  transform: {
+    '^.+\\.(ts|tsx)$': ['ts-jest', { tsconfig: 'tsconfig.jest.json' }]
+  }
+};

--- a/packages/biome-config/migrate.sh
+++ b/packages/biome-config/migrate.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Create Prettier config file.
+echo "📝 Creating Prettier config file..."
+echo "module.exports = require('../prettier-config/src/index.js');" > prettier.config.js
+
+# Run Biome migration commands.
+echo -e " 🚀 Running ESLint migration..."
+biome migrate eslint --write --include-inspired
+
+echo "🚀 Running Prettier migration..."
+biome migrate prettier --write
+
+# Clean up configuration files.
+echo "🧹 Cleaning up temporary files..."
+rm prettier.config.js
+
+echo "✅ Migration completed!"

--- a/packages/biome-config/package.json
+++ b/packages/biome-config/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@untile/biome-config",
+  "version": "3.1.0",
+  "description": "Untile-flavored Biome config",
+  "keywords": [
+    "biome",
+    "config",
+    "lint"
+  ],
+  "homepage": "https://github.com/untile/js-configs/tree/master/packages/biome-config/#readme",
+  "bugs": {
+    "url": "https://github.com/untile/js-configs/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/untile/js-configs.git"
+  },
+  "license": "MIT",
+  "main": "biome.json",
+  "files": [
+    "biome.json"
+  ],
+  "scripts": {
+    "lint": "eslint . --ignore-pattern 'test/fixtures/*'",
+    "migrate": "sh ./migrate.sh",
+    "release": "../../bin/release.sh @untile/biome-config",
+    "test": "jest",
+    "test:watch": "jest --watch --notify"
+  },
+  "lint-staged": {
+    "package.json": "sort-package-json"
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
+    "@types/jest": "^29.5.14",
+    "eslint": "^9.20.1",
+    "jest": "^29.7.0",
+    "react": "^19.0.0",
+    "ts-jest": "^29.2.5",
+    "typescript": "^5.7.3"
+  },
+  "peerDependencies": {
+    "@biomejs/biome": "^1.9"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/biome-config/test/fixtures/correct.tsx
+++ b/packages/biome-config/test/fixtures/correct.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+
+type Props = {
+  initialCount: number;
+};
+
+function Counter({ initialCount }: Props) {
+  const [count, setCount] = useState(initialCount);
+
+  const handleIncrement = () => {
+    setCount(count + 1);
+  };
+
+  return (
+    <div className={'counter'}>
+      <p>{`Current count: ${count}`}</p>
+
+      <button onClick={handleIncrement} type={'button'}>
+        {'Increment'}
+      </button>
+    </div>
+  );
+}
+
+export default Counter;

--- a/packages/biome-config/test/fixtures/incorrect.tsx
+++ b/packages/biome-config/test/fixtures/incorrect.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+function BadComponent(props) {
+  const count = 0;
+  const [state, setState] = useState<unknown>({ data: null });
+
+  function doManyThings(param1, param2, param3, param4, param5) {
+    if (param1 == null) {
+      console.log('Error');
+
+      return;
+    }
+  }
+
+  // Performance error.
+  delete window.something;
+
+  // Complexity error.
+  const Constructor = class {
+    constructor() {
+      super();
+    }
+  };
+
+  // React errors.
+  return (
+    <>
+      <div>
+        {/* Accessibility errors */}
+        <img src={'image.jpg'} />
+        <img alt='image of a thing' src='image.jpg' />
+        <img alt='photo image picture' src='image.jpg' />
+        <a>Link without href</a>
+        <button onClick={() => {}}>Button without type</button>
+        <div dangerouslySetInnerHTML={{ __html: '<p>Dangerous!</p>' }} />
+
+        {/* Suspicious errors */}
+        {count == 0 ? 'Zero' : count == 1 ? 'One' : 'Many'}
+
+        {/* React errors */}
+        <div children={<p>Text</p>} onClick={() => {}} />
+        <div onClick={() => {}} />
+      </div>
+    </>
+  );
+}
+
+export default BadComponent;

--- a/packages/biome-config/test/index.test.ts
+++ b/packages/biome-config/test/index.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Module dependencies.
+ */
+
+import { spawnSync } from 'child_process';
+import path from 'node:path';
+
+/**
+ * Run biome lint.
+ */
+
+const runBiomeLint = (file: string) => {
+  const filePath = path.resolve(__dirname, 'fixtures', file);
+  const result = spawnSync(
+    'npx',
+    [
+      '@biomejs/biome',
+      'lint',
+      '--files-ignore-unknown=true',
+      '--error-on-warnings',
+      '--verbose',
+      filePath
+    ],
+    {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe']
+    }
+  );
+
+  const errors = (result.stderr || result.stdout || '')
+    .split('\n')
+    .filter(line => line.includes('lint/'))
+    .map(line => {
+      const match = line.match(/lint\/([^/]+\/[^/\s]+)/);
+
+      return match ? `lint/${match[1]}` : '';
+    })
+    .filter(Boolean);
+
+  return {
+    errors: [...new Set(errors)],
+    success: errors.length === 0
+  };
+};
+
+/**
+ * Test suite.
+ */
+
+describe('biome configuration', () => {
+  it('correct.tsx should pass linting', () => {
+    const result = runBiomeLint('correct.tsx');
+
+    expect(result.success).toBe(true);
+  });
+
+  it('incorrect.tsx should fail with specific lint errors', () => {
+    const result = runBiomeLint('incorrect.tsx');
+
+    expect(result.success).toBe(false);
+    expect(result.errors).toEqual([
+      'lint/complexity/noUselessConstructor',
+      'lint/suspicious/noEmptyBlockStatements',
+      'lint/suspicious/noDoubleEquals',
+      'lint/correctness/noUnusedVariables',
+      'lint/suspicious/noConsole',
+      'lint/correctness/noChildrenProp'
+    ]);
+  });
+});

--- a/packages/biome-config/tsconfig.jest.json
+++ b/packages/biome-config/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "commonjs"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1282,6 +1282,97 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@biomejs/biome@npm:^1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/biome@npm:1.9.4"
+  dependencies:
+    "@biomejs/cli-darwin-arm64": "npm:1.9.4"
+    "@biomejs/cli-darwin-x64": "npm:1.9.4"
+    "@biomejs/cli-linux-arm64": "npm:1.9.4"
+    "@biomejs/cli-linux-arm64-musl": "npm:1.9.4"
+    "@biomejs/cli-linux-x64": "npm:1.9.4"
+    "@biomejs/cli-linux-x64-musl": "npm:1.9.4"
+    "@biomejs/cli-win32-arm64": "npm:1.9.4"
+    "@biomejs/cli-win32-x64": "npm:1.9.4"
+  dependenciesMeta:
+    "@biomejs/cli-darwin-arm64":
+      optional: true
+    "@biomejs/cli-darwin-x64":
+      optional: true
+    "@biomejs/cli-linux-arm64":
+      optional: true
+    "@biomejs/cli-linux-arm64-musl":
+      optional: true
+    "@biomejs/cli-linux-x64":
+      optional: true
+    "@biomejs/cli-linux-x64-musl":
+      optional: true
+    "@biomejs/cli-win32-arm64":
+      optional: true
+    "@biomejs/cli-win32-x64":
+      optional: true
+  bin:
+    biome: bin/biome
+  checksum: 10c0/b5655c5aed9a6fffe24f7d04f15ba4444389d0e891c9ed9106fab7388ac9b4be63185852cc2a937b22940dac3e550b71032a4afd306925cfea436c33e5646b3e
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-darwin-arm64@npm:1.9.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-darwin-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-darwin-x64@npm:1.9.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64-musl@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-arm64-musl@npm:1.9.4"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-arm64@npm:1.9.4"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64-musl@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-x64-musl@npm:1.9.4"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-linux-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-linux-x64@npm:1.9.4"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-arm64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-win32-arm64@npm:1.9.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@biomejs/cli-win32-x64@npm:1.9.4":
+  version: 1.9.4
+  resolution: "@biomejs/cli-win32-x64@npm:1.9.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@commitlint/cli@npm:^19.8.0":
   version: 19.8.0
   resolution: "@commitlint/cli@npm:19.8.0"
@@ -1556,7 +1647,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@eslint/config-array@npm:^0.19.2":
+"@eslint/config-array@npm:^0.19.0, @eslint/config-array@npm:^0.19.2":
   version: 0.19.2
   resolution: "@eslint/config-array@npm:0.19.2"
   dependencies:
@@ -1574,12 +1665,47 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/core@npm:^0.10.0":
+  version: 0.10.0
+  resolution: "@eslint/core@npm:0.10.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/074018075079b3ed1f14fab9d116f11a8824cdfae3e822badf7ad546962fafe717a31e61459bad8cc59cf7070dc413ea9064ddb75c114f05b05921029cde0a64
+  languageName: node
+  linkType: hard
+
+"@eslint/core@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@eslint/core@npm:0.11.0"
+  dependencies:
+    "@types/json-schema": "npm:^7.0.15"
+  checksum: 10c0/1e0671d035c908175f445864a7864cf6c6a8b67a5dfba8c47b2ac91e2d3ed36e8c1f2fd81d98a73264f8677055559699d4adb0f97d86588e616fc0dc9a4b86c9
+  languageName: node
+  linkType: hard
+
 "@eslint/core@npm:^0.12.0":
   version: 0.12.0
   resolution: "@eslint/core@npm:0.12.0"
   dependencies:
     "@types/json-schema": "npm:^7.0.15"
   checksum: 10c0/d032af81195bb28dd800c2b9617548c6c2a09b9490da3c5537fd2a1201501666d06492278bb92cfccac1f7ac249e58601dd87f813ec0d6a423ef0880434fa0c3
+  languageName: node
+  linkType: hard
+
+"@eslint/eslintrc@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "@eslint/eslintrc@npm:3.2.0"
+  dependencies:
+    ajv: "npm:^6.12.4"
+    debug: "npm:^4.3.2"
+    espree: "npm:^10.0.1"
+    globals: "npm:^14.0.0"
+    ignore: "npm:^5.2.0"
+    import-fresh: "npm:^3.2.1"
+    js-yaml: "npm:^4.1.0"
+    minimatch: "npm:^3.1.2"
+    strip-json-comments: "npm:^3.1.1"
+  checksum: 10c0/43867a07ff9884d895d9855edba41acf325ef7664a8df41d957135a81a477ff4df4196f5f74dc3382627e5cc8b7ad6b815c2cea1b58f04a75aced7c43414ab8b
   languageName: node
   linkType: hard
 
@@ -1600,6 +1726,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@eslint/js@npm:9.20.0":
+  version: 9.20.0
+  resolution: "@eslint/js@npm:9.20.0"
+  checksum: 10c0/10e7b5b9e628b5192e8fc6b0ecd27cf48322947e83e999ff60f9f9e44ac8d499138bcb9383cbfa6e51e780d53b4e76ccc2d1753b108b7173b8404fd484d37328
+  languageName: node
+  linkType: hard
+
 "@eslint/js@npm:9.22.0":
   version: 9.22.0
   resolution: "@eslint/js@npm:9.22.0"
@@ -1611,6 +1744,16 @@ __metadata:
   version: 2.1.6
   resolution: "@eslint/object-schema@npm:2.1.6"
   checksum: 10c0/b8cdb7edea5bc5f6a96173f8d768d3554a628327af536da2fc6967a93b040f2557114d98dbcdbf389d5a7b290985ad6a9ce5babc547f36fc1fde42e674d11a56
+  languageName: node
+  linkType: hard
+
+"@eslint/plugin-kit@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "@eslint/plugin-kit@npm:0.2.5"
+  dependencies:
+    "@eslint/core": "npm:^0.10.0"
+    levn: "npm:^0.4.1"
+  checksum: 10c0/ba9832b8409af618cf61791805fe201dd62f3c82c783adfcec0f5cd391e68b40beaecb47b9a3209e926dbcab65135f410cae405b69a559197795793399f61176
   languageName: node
   linkType: hard
 
@@ -1652,6 +1795,13 @@ __metadata:
   version: 0.3.1
   resolution: "@humanwhocodes/retry@npm:0.3.1"
   checksum: 10c0/f0da1282dfb45e8120480b9e2e275e2ac9bbe1cf016d046fdad8e27cc1285c45bb9e711681237944445157b430093412b4446c1ab3fc4bb037861b5904101d3b
+  languageName: node
+  linkType: hard
+
+"@humanwhocodes/retry@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@humanwhocodes/retry@npm:0.4.1"
+  checksum: 10c0/be7bb6841c4c01d0b767d9bb1ec1c9359ee61421ce8ba66c249d035c5acdfd080f32d55a5c9e859cdd7868788b8935774f65b2caf24ec0b7bd7bf333791f063b
   languageName: node
   linkType: hard
 
@@ -2685,6 +2835,22 @@ __metadata:
   checksum: 10c0/6428c1ba199d962060d43f06ba8a98b874ba6fe875a23b10e8f01550838d8be8ee689ae4da3e8b045d4c7bb01e38385e6a8ae17a9d566cf7cd21f7090b573f61
   languageName: node
   linkType: hard
+
+"@untile/biome-config@workspace:packages/biome-config":
+  version: 0.0.0-use.local
+  resolution: "@untile/biome-config@workspace:packages/biome-config"
+  dependencies:
+    "@biomejs/biome": "npm:^1.9.4"
+    "@types/jest": "npm:^29.5.14"
+    eslint: "npm:^9.20.1"
+    jest: "npm:^29.7.0"
+    react: "npm:^19.0.0"
+    ts-jest: "npm:^29.2.5"
+    typescript: "npm:^5.7.3"
+  peerDependencies:
+    "@biomejs/biome": ^1.9
+  languageName: unknown
+  linkType: soft
 
 "@untile/commitlint-config@workspace:packages/commitlint-config":
   version: 0.0.0-use.local
@@ -4976,6 +5142,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-scope@npm:^8.2.0":
+  version: 8.2.0
+  resolution: "eslint-scope@npm:8.2.0"
+  dependencies:
+    esrecurse: "npm:^4.3.0"
+    estraverse: "npm:^5.2.0"
+  checksum: 10c0/8d2d58e2136d548ac7e0099b1a90d9fab56f990d86eb518de1247a7066d38c908be2f3df477a79cf60d70b30ba18735d6c6e70e9914dca2ee515a729975d70d6
+  languageName: node
+  linkType: hard
+
 "eslint-scope@npm:^8.3.0":
   version: 8.3.0
   resolution: "eslint-scope@npm:8.3.0"
@@ -5011,6 +5187,55 @@ __metadata:
   version: 4.2.0
   resolution: "eslint-visitor-keys@npm:4.2.0"
   checksum: 10c0/2ed81c663b147ca6f578312919483eb040295bbab759e5a371953456c636c5b49a559883e2677112453728d66293c0a4c90ab11cab3428cf02a0236d2e738269
+  languageName: node
+  linkType: hard
+
+"eslint@npm:^9.20.1":
+  version: 9.20.1
+  resolution: "eslint@npm:9.20.1"
+  dependencies:
+    "@eslint-community/eslint-utils": "npm:^4.2.0"
+    "@eslint-community/regexpp": "npm:^4.12.1"
+    "@eslint/config-array": "npm:^0.19.0"
+    "@eslint/core": "npm:^0.11.0"
+    "@eslint/eslintrc": "npm:^3.2.0"
+    "@eslint/js": "npm:9.20.0"
+    "@eslint/plugin-kit": "npm:^0.2.5"
+    "@humanfs/node": "npm:^0.16.6"
+    "@humanwhocodes/module-importer": "npm:^1.0.1"
+    "@humanwhocodes/retry": "npm:^0.4.1"
+    "@types/estree": "npm:^1.0.6"
+    "@types/json-schema": "npm:^7.0.15"
+    ajv: "npm:^6.12.4"
+    chalk: "npm:^4.0.0"
+    cross-spawn: "npm:^7.0.6"
+    debug: "npm:^4.3.2"
+    escape-string-regexp: "npm:^4.0.0"
+    eslint-scope: "npm:^8.2.0"
+    eslint-visitor-keys: "npm:^4.2.0"
+    espree: "npm:^10.3.0"
+    esquery: "npm:^1.5.0"
+    esutils: "npm:^2.0.2"
+    fast-deep-equal: "npm:^3.1.3"
+    file-entry-cache: "npm:^8.0.0"
+    find-up: "npm:^5.0.0"
+    glob-parent: "npm:^6.0.2"
+    ignore: "npm:^5.2.0"
+    imurmurhash: "npm:^0.1.4"
+    is-glob: "npm:^4.0.0"
+    json-stable-stringify-without-jsonify: "npm:^1.0.1"
+    lodash.merge: "npm:^4.6.2"
+    minimatch: "npm:^3.1.2"
+    natural-compare: "npm:^1.4.0"
+    optionator: "npm:^0.9.3"
+  peerDependencies:
+    jiti: "*"
+  peerDependenciesMeta:
+    jiti:
+      optional: true
+  bin:
+    eslint: bin/eslint.js
+  checksum: 10c0/056789dd5a00897730376f8c0a191e22840e97b7276916068ec096341cb2ec3a918c8bd474bf94ccd7b457ad9fbc16e5c521a993c7cc6ebcf241933e2fd378b0
   languageName: node
   linkType: hard
 
@@ -10660,6 +10885,43 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: 10c0/23fd56a958b332cac00150a652e4c84730df30571bd2faa1ba6d7b511356d1a61656621492bb6c7f15dd6e18847a1408357a0e406671d358115369a17f5bfedd
+  languageName: node
+  linkType: hard
+
+"ts-jest@npm:^29.2.5":
+  version: 29.2.5
+  resolution: "ts-jest@npm:29.2.5"
+  dependencies:
+    bs-logger: "npm:^0.2.6"
+    ejs: "npm:^3.1.10"
+    fast-json-stable-stringify: "npm:^2.1.0"
+    jest-util: "npm:^29.0.0"
+    json5: "npm:^2.2.3"
+    lodash.memoize: "npm:^4.1.2"
+    make-error: "npm:^1.3.6"
+    semver: "npm:^7.6.3"
+    yargs-parser: "npm:^21.1.1"
+  peerDependencies:
+    "@babel/core": ">=7.0.0-beta.0 <8"
+    "@jest/transform": ^29.0.0
+    "@jest/types": ^29.0.0
+    babel-jest: ^29.0.0
+    jest: ^29.0.0
+    typescript: ">=4.3 <6"
+  peerDependenciesMeta:
+    "@babel/core":
+      optional: true
+    "@jest/transform":
+      optional: true
+    "@jest/types":
+      optional: true
+    babel-jest:
+      optional: true
+    esbuild:
+      optional: true
+  bin:
+    ts-jest: cli.js
+  checksum: 10c0/acb62d168faec073e64b20873b583974ba8acecdb94681164eb346cef82ade8fb481c5b979363e01a97ce4dd1e793baf64d9efd90720bc941ad7fc1c3d6f3f68
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Add Biome configuration

This PR introduces a new package `@untile/biome-config` that provides Untile's opinionated configuration for [biomejs](https://biomejs.dev), a fast JavaScript/TypeScript linter written in Rust.

The initial configuration was generated using Biome's migration tool, which converted our existing Prettier and TypeScript React configurations into Biome's format, ensuring a smooth transition from our current setup.

## What's Changed

- Creates base configuration package for Biome
- Migrates existing Untile's Prettier and TypeScript React rules using Biome's migration tool
- Sets up initial linting rules focusing on:
  - Complexity (e.g., useless constructors)
  - Suspicious patterns (e.g., console.log, double equals)
  - Correctness (e.g., unused variables, children prop usage)
- Adds test suite to validate configured rules

## How to Use

1. Install the package:
```bash
yarn add -D @untile/biome-config
```

2. Create a `biome.json` file in your project root:
```json
{
  "extends": ["@untile/biome-config"]
}
```

3. Run Biome:
```bash
yarn biome check .
```