### PR TITLE
Remove eslint-config-prettier

### DIFF
--- a/packages/eslint-config-typescript-react/package.json
+++ b/packages/eslint-config-typescript-react/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "@untile/eslint-config-react": "^3.0.0",
-    "@untile/eslint-config-typescript": "^3.0.0",
-    "eslint-config-prettier": "^10.0.1"
+    "@untile/eslint-config-typescript": "^3.0.0"
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",

--- a/packages/eslint-config-typescript-react/src/index.js
+++ b/packages/eslint-config-typescript-react/src/index.js
@@ -2,7 +2,6 @@
  * Module dependencies.
  */
 
-const eslintConfigPrettier = require('eslint-config-prettier');
 const eslintConfigReact = require('@untile/eslint-config-react');
 const eslintConfigTypescript = require('@untile/eslint-config-typescript');
 
@@ -10,8 +9,4 @@ const eslintConfigTypescript = require('@untile/eslint-config-typescript');
  * Export `@untile/eslint-config-typescript-react` configuration preset.
  */
 
-module.exports = [
-  ...eslintConfigReact,
-  ...eslintConfigTypescript,
-  eslintConfigPrettier
-];
+module.exports = [...eslintConfigReact, ...eslintConfigTypescript];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1912,7 +1912,6 @@ __metadata:
     "@untile/eslint-config-react": "npm:^3.0.0"
     "@untile/eslint-config-typescript": "npm:^3.0.0"
     eslint: "npm:^9.20.1"
-    eslint-config-prettier: "npm:^10.0.1"
     jest: "npm:^29.7.0"
     react: "npm:^19.0.0"
     ts-jest: "npm:^29.2.5"
@@ -3635,17 +3634,6 @@ __metadata:
   peerDependencies:
     eslint: ">=6.0.0"
   checksum: 10c0/325e815205fab70ebcd379f6d4b5d44c7d791bb8dfe0c9888233f30ebabd9418422595b53a781b946c768d9244d858540e5e6129a6b3dd6d606f467d599edc6c
-  languageName: node
-  linkType: hard
-
-"eslint-config-prettier@npm:^10.0.1":
-  version: 10.0.1
-  resolution: "eslint-config-prettier@npm:10.0.1"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: build/bin/cli.js
-  checksum: 10c0/e2434931669d211663c0493f2c1640a670a02ba4503a68f056a7eda133f383acbbb983a4a7bd0ad6cb3b2bc4d5731c3be8b32fe28e35087a76fea45f7061ae70
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Remove eslint-config-prettier from package dependencies

## Why
With ESLint 9's flat config system, eslint-config-prettier must be the last rule in the ESLint configuration to properly disable conflicting rules. When other projects extend Untile's ESLint config, this can cause issues with rule ordering and unexpected behavior.

## What
- Remove `eslint-config-prettier` from package dependencies
- Each project should now manage eslint-config-prettier independently to ensure proper rule ordering

## Impact
This change allows for better control of prettier-related ESLint rules in individual projects and prevents potential conflicts when extending this configuration. Projects using this config will need to manually add and configure eslint-config-prettier in their own ESLint setup.