### PR TITLE
Fix perfectionist/sort-imports rule

### DIFF
--- a/packages/eslint-config/src/index.js
+++ b/packages/eslint-config/src/index.js
@@ -241,6 +241,9 @@ module.exports = [
           prev: '*'
         }
       ],
+      'perfectionist/sort-imports': ['error', {
+        newlinesBetween: 'ignore'
+      }],
       'perfectionist/sort-modules': 'off',
       'prefer-arrow-callback': 'error',
       'prefer-const': 'error',


### PR DESCRIPTION
This PR fixes `perfectionist/sort-imports` rule to ignore new line between blocks.

bad
```js
import path from 'node:path';

import config from 'foo/bar/config'
```

correct
```js
import path from 'node:path';
import config from 'foo/bar/config'
```